### PR TITLE
Update .travis.yml w.r.t praw 6.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: python
 
 python:
-  - "3.6.1"
+  - "3.8"
 
 before_install:
   - sudo apt-get update


### PR DESCRIPTION
Praw 6.5 added usage of `NoReturn` which is not supported in 3.6.1. Changing python version to 3.8.

Issue is also filed in praw repo: https://github.com/praw-dev/praw/issues/1271.
Changeset: https://github.com/praw-dev/praw/pull/1173