### PR TITLE
use rapidfuzz instead of fuzzywuzzy

### DIFF
--- a/parsers/css_parser.py
+++ b/parsers/css_parser.py
@@ -5,7 +5,7 @@ import json
 import re
 
 import requests
-from fuzzywuzzy import process
+from rapidfuzz import process
 
 from config import STYLESHEET_URL, FLAIR_REGEX, USER_AGENT
 from util.database.database import db_api
@@ -17,7 +17,7 @@ def populate_heroes():
     """Method to update heroes in the Heroes table with hero names and proper css classes names as
     taken from the DotA2 subreddit and hero flair images from the reddit directory.
 
-    Uses fuzzywuzzy for fuzzy matching of hero names to name found in `.flair-name` property in css.
+    Uses rapidfuzz for fuzzy matching of hero names to name found in `.flair-name` property in css.
     """
     hero_names = db_api.get_all_hero_names()
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,8 +4,7 @@ praw
 psycopg2
 redis
 pony
-fuzzywuzzy
+rapidfuzz
 requests
-python-Levenshtein
 cacheout
 requests-futures


### PR DESCRIPTION
FuzzyWuzzy is GPLv2 licensed which would force you to licence the whole project under GPLv2. I had the same problem on one of my projects and so I wrote [rapidfuzz](https://github.com/rhasspy/rapidfuzz) which is implementing the same algorithm but is based on a version of fuzzywuzzy that was MIT Licensed and is therefor MIT Licensed aswell, so it can be used in here without forcing a License change. As a nice bonus it is fully implemented in C++ and comes with a few Algorithmic improvements making it between 5 and 100 times faster than FuzzyWuzzy.