### PR TITLE
Added two ways to request hero specific responses

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: python
 
 python:
-  - "3.8"
+  - "3.6.4"
 
 before_install:
   - sudo apt-get update

--- a/README.md
+++ b/README.md
@@ -58,7 +58,6 @@ Config variables needed to be set in environment for running the bot:
 #### 3.1
 *   Users can now request for a hero specific response by adding ```hero_name ::``` prefix to the response.
     Has more priority than user's flair.
-*   Easter eggs
 
 #### 3.0
 Major revamp for the bot.

--- a/README.md
+++ b/README.md
@@ -55,6 +55,10 @@ Config variables needed to be set in environment for running the bot:
 ---
 ### Changelog
 
+#### 3.2
+*   User(OP) can now request to update the response using another comment under bot's comment.
+    The comment should be in format ```No, I want <hero_name>``` 
+
 #### 3.1
 *   Users can now request for a hero specific response by adding ```<hero_name> ::``` prefix to the response.
     Has more priority than user's flair.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 ## Dota Responses Reddit Bot
-[![Python 3.6](https://img.shields.io/badge/python-3.6-blue.svg)](https://www.python.org/downloads/release/python-360/)
+[![Python 3.6.4](https://img.shields.io/badge/python-3.6.4-blue.svg)](https://www.python.org/downloads/release/python-364/)
 [![Build Status](https://api.travis-ci.org/Jonarzz/DotaResponsesRedditBot.svg?branch=master)](https://travis-ci.org/Jonarzz/DotaResponsesRedditBot)
 [![Maintainability](https://api.codeclimate.com/v1/badges/de2c724018076b34064f/maintainability)](https://codeclimate.com/github/Jonarzz/DotaResponsesRedditBot/maintainability)
 [![codecov](https://codecov.io/gh/Jonarzz/DotaResponsesRedditBot/branch/master/graph/badge.svg)](https://codecov.io/gh/Jonarzz/DotaResponsesRedditBot)

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Config variables needed to be set in environment for running the bot:
 ### Changelog
 
 #### 3.1
-*   Users can now request for a hero specific response by adding ```hero_name ::``` prefix to the response.
+*   Users can now request for a hero specific response by adding ```<hero_name> ::``` prefix to the response.
     Has more priority than user's flair.
 
 #### 3.0

--- a/README.md
+++ b/README.md
@@ -55,6 +55,11 @@ Config variables needed to be set in environment for running the bot:
 ---
 ### Changelog
 
+#### 3.1
+*   Users can now request for a hero specific response by adding ```hero_name ::``` prefix to the response.
+    Has more priority than user's flair.
+*   Easter eggs
+
 #### 3.0
 Major revamp for the bot.
 Things that are new:

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ For example: `"Selemene commands"` will return a Luna response *(like on the scr
 *   If comment has blockquote, first blockquote is considered for matching.
 
 <!-- Old behavior
-All the responses are in lowercase in the dictionary, before comparision the comments are parsed to lowercase as well. Dot or exclamation mark ending the replyable is ignored.
+All the responses are in lowercase in the dictionary, before comparison the comments are parsed to lowercase as well. Dot or exclamation mark ending the replyable is ignored.
 -->
 <!-- Old behavior
 The bot will try to match a response of the hero that is in the comment/submission's author flair. If it does not find an appropriate one, it takes the one of the first hero that has such a response (alphabetically).
@@ -55,11 +55,9 @@ Config variables needed to be set in environment for running the bot:
 ---
 ### Changelog
 
-#### 3.2
-*   User(OP) can now request to update the response using another comment under bot's comment.
-    The comment should be in format ```No, I want <hero_name>``` 
-
 #### 3.1
+*   User(OP) can now request to update the response using another comment under bot's comment.
+    The comment should be in the format ```Try <hero_name>``` 
 *   Users can now request for a hero specific response by adding ```<hero_name> ::``` prefix to the response.
     Has more priority than user's flair.
 

--- a/bot/worker.py
+++ b/bot/worker.py
@@ -6,6 +6,7 @@ prepared. The response is posted as a reply to the original comment/submission o
 """
 import time
 
+from praw.exceptions import APIException
 from praw.models import Comment
 from prawcore import ServerError
 
@@ -47,6 +48,9 @@ def work():
                 process_replyable(reddit, submission)
         except ServerError as e:
             logger.critical("Reddit server is down : " + str(e))
+            time.sleep(120)
+        except APIException as e:
+            logger.critical("API Exception occurred : " + str(e))
             time.sleep(60)
 
 

--- a/bot/worker.py
+++ b/bot/worker.py
@@ -173,6 +173,10 @@ def is_hero_specific_response(text):
     """
     if '::' in text:
         hero_name, text = text.split('::', 1)
+
+        if not hero_name or not text:
+            return False
+
         hero_id = db_api.get_hero_id_by_name(hero_name=hero_name)
         if hero_id:
             link, _ = db_api.get_link_for_response(processed_text=text, hero_id=hero_id)

--- a/bot/worker.py
+++ b/bot/worker.py
@@ -34,8 +34,8 @@ def work():
     reddit = account.get_account()
     logger.info('Connected to Reddit account : ' + config.USERNAME)
 
-    comment_stream = reddit.subreddit(config.SUBREDDIT).stream.comments(pause_after=-1)
-    submission_stream = reddit.subreddit(config.SUBREDDIT).stream.submissions(pause_after=-1)
+    comment_stream = reddit.subreddit(config.SUBREDDIT).stream.comments(pause_after=-1, skip_existing=True)
+    submission_stream = reddit.subreddit(config.SUBREDDIT).stream.submissions(pause_after=-1, skip_existing=True)
     while True:
         try:
             for comment in comment_stream:
@@ -46,8 +46,8 @@ def work():
                 if submission is None:
                     break
                 process_replyable(reddit, submission)
-        except ServerError:
-            logger.critical("Reddit server is down")
+        except ServerError as e:
+            logger.critical("Reddit server is down" + str(e))
             time.sleep(60)
 
 

--- a/bot/worker.py
+++ b/bot/worker.py
@@ -34,9 +34,10 @@ def work():
     reddit = account.get_account()
     logger.info('Connected to Reddit account : ' + config.USERNAME)
 
-    comment_stream = reddit.subreddit(config.SUBREDDIT).stream.comments(pause_after=-1, skip_existing=True)
-    submission_stream = reddit.subreddit(config.SUBREDDIT).stream.submissions(pause_after=-1, skip_existing=True)
     while True:
+        # Streams need to be restarted when they throw exception
+        comment_stream = reddit.subreddit(config.SUBREDDIT).stream.comments(pause_after=-1, skip_existing=True)
+        submission_stream = reddit.subreddit(config.SUBREDDIT).stream.submissions(pause_after=-1, skip_existing=True)
         try:
             for comment in comment_stream:
                 if comment is None:
@@ -47,7 +48,7 @@ def work():
                     break
                 process_replyable(reddit, submission)
         except ServerError as e:
-            logger.critical("Reddit server is down" + str(e))
+            logger.critical("Reddit server is down : " + str(e))
             time.sleep(60)
 
 

--- a/bot/worker.py
+++ b/bot/worker.py
@@ -79,7 +79,7 @@ def process_replyable(reddit, replyable):
     if replyable.author == reddit.user.me:
         return
 
-    logger.debug("Found new replyable: " + str(replyable.fullname))
+    logger.info("Found new replyable: " + str(replyable.fullname))
 
     processed_body = process_body(replyable.body if isinstance(replyable, Comment) else replyable.title)
 

--- a/bot/worker.py
+++ b/bot/worker.py
@@ -6,8 +6,10 @@ prepared. The response is posted as a reply to the original comment/submission o
 
 Proper logging is provided - saved to 2 files as standard output and errors.
 """
+import time
 
 from praw.models import Comment
+from prawcore import ServerError
 
 import config
 from bot import account
@@ -35,14 +37,18 @@ def work():
     comment_stream = reddit.subreddit(config.SUBREDDIT).stream.comments(pause_after=-1)
     submission_stream = reddit.subreddit(config.SUBREDDIT).stream.submissions(pause_after=-1)
     while True:
-        for comment in comment_stream:
-            if comment is None:
-                break
-            process_replyable(reddit, comment)
-        for submission in submission_stream:
-            if submission is None:
-                break
-            process_replyable(reddit, submission)
+        try:
+            for comment in comment_stream:
+                if comment is None:
+                    break
+                process_replyable(reddit, comment)
+            for submission in submission_stream:
+                if submission is None:
+                    break
+                process_replyable(reddit, submission)
+        except ServerError:
+            logger.critical("Reddit server is down")
+            time.sleep(60)
 
 
 def process_replyable(reddit, replyable):

--- a/bot/worker.py
+++ b/bot/worker.py
@@ -36,8 +36,8 @@ def work():
 
     while True:
         # Streams need to be restarted when they throw exception
-        comment_stream = reddit.subreddit(config.SUBREDDIT).stream.comments(pause_after=-1, skip_existing=True)
-        submission_stream = reddit.subreddit(config.SUBREDDIT).stream.submissions(pause_after=-1, skip_existing=True)
+        comment_stream = reddit.subreddit(config.SUBREDDIT).stream.comments(pause_after=-1)
+        submission_stream = reddit.subreddit(config.SUBREDDIT).stream.submissions(pause_after=-1)
         try:
             for comment in comment_stream:
                 if comment is None:

--- a/bot/worker.py
+++ b/bot/worker.py
@@ -65,7 +65,7 @@ def process_replyable(reddit, replyable):
     Otherwise, when the bot is restarted it might reply twice to same comments. If replyable id is in the already present
     in the cache_api, then it is ignored, else processed and added to the cache_api.
     * Self comments are ignored.
-    * It is prepared for comparision to the responses in dictionary.
+    * It is prepared for comparison to the responses in dictionary.
     * If the replyable is not on the excluded responses list (loaded from config) and if it is in the responses db or
     specific responses list, a reply replyable is prepared and posted.
 
@@ -78,13 +78,14 @@ def process_replyable(reddit, replyable):
         return
 
     # Ignore thyself
-    if replyable.author == reddit.user.me:
+    if replyable.author == reddit.user.me():
         return
 
     logger.info("Found new replyable: " + replyable.fullname)
 
     processed_text = process_text(replyable.body if isinstance(replyable, Comment) else replyable.title)
 
+    # TODO make use of assignment expression for all below
     if is_excluded_response(processed_text):
         pass
     elif is_custom_response(processed_text):

--- a/bot/worker.py
+++ b/bot/worker.py
@@ -90,6 +90,20 @@ def process_replyable(reddit, replyable):
         add_regular_reply(replyable, processed_body)
 
 
+def get_quoted_text(body_text):
+    """Method used to get quoted text.
+    If body text contains a quote, the first quote text is considered as the body text.
+
+    :param body_text: The replyable body text
+    :return: The first quote in the body text. If no quotes are found, then the entire body text
+    """
+    lines = body_text.split('\n\n')
+    for line in lines:
+        if line.startswith('>'):
+            return line
+    return body_text
+
+
 def process_body(body_text):
     """Method used to clean the replyable body text.
     If body text contains a quote, the first quote text is considered as the body text.
@@ -102,11 +116,7 @@ def process_body(body_text):
     """
 
     if '>' in body_text:
-        lines = body_text.split('\n\n')
-        for line in lines:
-            if line.startswith('>'):
-                body_text = line
-                break
+        body_text = get_quoted_text(body_text)
 
     return preprocess_text(body_text)
 
@@ -175,6 +185,9 @@ def create_reply(replyable, response_url, hero_id, img=None):
     :return: The text for the comment reply.
     """
     original_text = replyable.body if isinstance(replyable, Comment) else replyable.title
+    original_text = original_text.strip()
+    if '>' in original_text:
+        original_text = get_quoted_text(original_text).strip()
 
     hero_name = db_api.get_hero_name(hero_id)
     return "[{}]({}) (sound warning: {}){}".format(original_text, response_url, hero_name, config.COMMENT_ENDING)

--- a/config.py
+++ b/config.py
@@ -58,7 +58,7 @@ Bleep bloop, I am a robot.
 [*^(Source)*](https://github.com/Jonarzz/DotaResponsesRedditBot) *^(|)* 
 [*^(Suggestions/Issues)*](https://github.com/Jonarzz/DotaResponsesRedditBot/issues/new/choose) *^(|)* 
 [*^(Maintainer)*](https://www.reddit.com/user/MePsyDuck/) *^(|)* 
-[*^(Author)*](https://www.reddit.com/user/Jonarz/) *^(|)*
+[*^(Author)*](https://www.reddit.com/user/Jonarz/)
 '''
 
 # Key should be lowercase without special characters. Needs to be updated if links break (as links can be
@@ -138,6 +138,7 @@ COMMON_PHRASE_RESPONSES = {'earth shaker', 'shut up', 'skeleton king', 'it begin
                            'about time', 'are you kidding me', 'abyssal underlord', 'so beautiful', 'nice try',
                            'thank you so much', 'ah, nice', 'nice one', 'eul s scepter', 'thank you',
                            'scepter of divinity', 'at last', 'too soon', 'try again', 'i don t think so', 'try harder',
-                           'well said', 'of course', 'got it', 'what happened', 'hey now', 'seems fair', 'that s right'}
+                           'well said', 'of course', 'got it', 'what happened', 'hey now', 'seems fair', 'that s right',
+                           'all pick'}
 
 EXCLUDED_RESPONSES = FREQUENT_RESPONSES | ITEM_RESPONSES | HERO_NAME_RESPONSES | COMMON_PHRASE_RESPONSES

--- a/config.py
+++ b/config.py
@@ -50,6 +50,8 @@ PRAW_FILENAME = 'praw.log'
 CACHE_TTL = 5
 
 # Responses config
+# TODO confirm this keyword
+UPDATE_REQUEST_KEYWORD = 'try '
 COMMENT_ENDING = '''
 
 ---

--- a/config.py
+++ b/config.py
@@ -78,7 +78,7 @@ FREQUENT_RESPONSES = {'denied', 'yes', 'not yet', 'no mana', 'not enough mana', 
                       'it s not time yet', 'ah', 'no', 'uh', 'ha ha', 'attack', 'haste', 'double damage', 'immortality',
                       'invisibility', 'illusion', 'regeneration', 'uh uh', 'ha', }
 
-# TODO Get them from here.
+# Note: Get them from here.
 # https://dota2.gamepedia.com/api.php?action=cargoquery&tables=items&fields=title&where=game+IS+NULL&limit=500&format=json
 ITEM_RESPONSES = {'crimson guard', 'vanguard', 'blades of attack', 'glimmer cape', 'aghanim s scepter', 'manta style',
                   'battle fury', 'yasha and kaya', 'talisman of evasion', 'sentry ward', 'yasha',
@@ -109,7 +109,7 @@ ITEM_RESPONSES = {'crimson guard', 'vanguard', 'blades of attack', 'glimmer cape
                   'hurricane pike', 'vladmir s offering', 'tranquil boots', 'javelin', 'meteor hammer', 'broadsword',
                   'ultimate orb'}
 
-# TODO Get them from here
+# Note: Get them from here
 # https://dota2.gamepedia.com/api.php?action=cargoquery&tables=heroes&fields=title&where=game+IS+NULL&limit=500&format=json
 HERO_NAME_RESPONSES = {'silencer', 'phantom assassin', 'clinkz', 'huskar', 'juggernaut', 'crystal maiden', 'pudge',
                        'disruptor', 'queen of pain', 'wraith king', 'spectre', 'templar assassin', 'warlock',

--- a/config.py
+++ b/config.py
@@ -53,7 +53,7 @@ CACHE_TTL = 5
 COMMENT_ENDING = '''
 
 ---
-Bleep bloop, I am a robot.
+Bleep bloop, I am a robot. *OP can reply with "Try hero_name" to update this with new hero*
 
 [*^(Source)*](https://github.com/Jonarzz/DotaResponsesRedditBot) *^(|)* 
 [*^(Suggestions/Issues)*](https://github.com/Jonarzz/DotaResponsesRedditBot/issues/new/choose) *^(|)* 

--- a/config.py
+++ b/config.py
@@ -57,9 +57,8 @@ Bleep bloop, I am a robot.
 
 [*^(Source)*](https://github.com/Jonarzz/DotaResponsesRedditBot) *^(|)* 
 [*^(Suggestions/Issues)*](https://github.com/Jonarzz/DotaResponsesRedditBot/issues/new/choose) *^(|)* 
-[*^(Contact)*](https://www.reddit.com/user/MePsyDuck/) *^(|)* 
-[*^(Author)*](https://www.reddit.com/user/Jonarz/) *^(|)* 
-[*^(Host)*](https://www.reddit.com/user/iggys_reddit_account/)
+[*^(Maintainer)*](https://www.reddit.com/user/MePsyDuck/) *^(|)* 
+[*^(Author)*](https://www.reddit.com/user/Jonarz/) *^(|)*
 '''
 
 # Key should be lowercase without special characters. Needs to be updated if links break (as links can be

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -17,16 +17,16 @@ class BotWorkerTest(unittest.TestCase):
     """
 
     def test_parse_comment(self):
-        """Method that tests the process_body method from worker module.
+        """Method that tests the process_text method from worker module.
         """
-        self.assertEqual(worker.process_body(
+        self.assertEqual(worker.process_text(
             "That's a great idea!!!"), "that s a great idea")
-        self.assertEqual(worker.process_body("  WoNdErFuL  "), "wonderful")
-        self.assertEqual(worker.process_body("How are you?"), "how are you")
-        self.assertEqual(worker.process_body(
+        self.assertEqual(worker.process_text("  WoNdErFuL  "), "wonderful")
+        self.assertEqual(worker.process_text("How are you?"), "how are you")
+        self.assertEqual(worker.process_text(
             "Isn't is good to have quotes?  you can add any response in quote and bot would still \n\n> reply to them"),
             "reply to them")
-        self.assertEqual(worker.process_body(
+        self.assertEqual(worker.process_text(
             "> multiple quotes \n\n > but reply to \n\n > only first one"), "multiple quotes")
 
     def test_account(self):

--- a/util/caching/caching.py
+++ b/util/caching/caching.py
@@ -10,21 +10,21 @@ __author__ = 'MePsyDuck'
 
 class CacheAPI(ABC):
     @abstractmethod
-    def _check(self, key):
+    def _exists(self, key):
         pass
 
     @abstractmethod
     def _set(self, key):
         pass
 
-    def check(self, thing_id):
+    def exists(self, thing_id):
         """Check if Reddit thing (currently comment/submission) is already processed/replied.
         If it is not in the cache, it adds the thing_id to cache.
 
         :param thing_id: They id of comment/submission to be cached.
         :returns: `True` if replyable exists, else `False`.
         """
-        if self._check(thing_id):
+        if self._exists(thing_id):
             return True
         else:
             self._set(thing_id)

--- a/util/caching/db_cache.py
+++ b/util/caching/db_cache.py
@@ -9,7 +9,7 @@ __author__ = 'MePsyDuck'
 
 
 class DBCache(CacheAPI):
-    def _check(self, key):
+    def _exists(self, key):
         """Method to check if key exists in DB cache.
 
         :param key: The `key` to to be checked in DB cache.

--- a/util/caching/memory_cache.py
+++ b/util/caching/memory_cache.py
@@ -6,6 +6,7 @@ JSON File used to dump data on shutdown and load it back up on startup.
 import atexit
 import json
 import os
+import signal
 from collections import OrderedDict
 
 from cacheout import FIFOCache
@@ -26,6 +27,8 @@ class MemoryCache(CacheAPI):
                 old_cache = json.load(cache_json, object_pairs_hook=OrderedDict)
                 self.cache.set_many(old_cache)
         atexit.register(self._cleanup)
+        signal.signal(signal.SIGTERM, self._cleanup)
+        signal.signal(signal.SIGINT, self._cleanup)
 
     def _cleanup(self):
         """Method to dump cache data to json file on script interrupt/shutdown.

--- a/util/caching/memory_cache.py
+++ b/util/caching/memory_cache.py
@@ -6,7 +6,6 @@ JSON File used to dump data on shutdown and load it back up on startup.
 import atexit
 import json
 import os
-import signal
 from collections import OrderedDict
 
 from cacheout import FIFOCache
@@ -27,8 +26,6 @@ class MemoryCache(CacheAPI):
                 old_cache = json.load(cache_json, object_pairs_hook=OrderedDict)
                 self.cache.set_many(old_cache)
         atexit.register(self._cleanup)
-        signal.signal(signal.SIGTERM, self._cleanup)
-        signal.signal(signal.SIGINT, self._cleanup)
 
     def _cleanup(self):
         """Method to dump cache data to json file on script interrupt/shutdown.

--- a/util/caching/memory_cache.py
+++ b/util/caching/memory_cache.py
@@ -36,7 +36,7 @@ class MemoryCache(CacheAPI):
         with open(CACHE_URL, 'w+') as cache_json:
             json.dump(self.cache.copy(), cache_json)
 
-    def _check(self, key):
+    def _exists(self, key):
         """Method to check if key exists in cache.
 
         :param key: The `key` to to be checked in cache.

--- a/util/caching/redis_cache.py
+++ b/util/caching/redis_cache.py
@@ -18,7 +18,7 @@ class RedisCache(CacheAPI):
         self.redis = Redis.from_url(CACHE_URL)
         logger.info('Connected to Redis at ' + CACHE_URL)
 
-    def _check(self, key):
+    def _exists(self, key):
         """Method to check if `key` exists in redis cache.
 
         :param key: The `key` to to be checked in redis cache.

--- a/util/database/database.py
+++ b/util/database/database.py
@@ -36,24 +36,21 @@ class DatabaseAPI:
     # Responses table queries
     @db_session
     def get_link_for_response(self, processed_text, hero_id=None):
-        """Method that returns the link for the processed response text. First tries to match with the given hero_id,
-        otherwise returns random result.
+        """Method that returns the link for the processed response text and given optional hero_id. If multiple matching
+        entries are found, returns a random result.
 
         :param processed_text: The plain processed response text.
         :param hero_id: The hero's id.
-        :return The link to the response
+       :return The link to the response, hero_id, or else None, None if no matching response is found.
         """
-        # TODO review
-        responses = Responses.select(lambda r: r.processed_text == processed_text)
+        if hero_id:
+            responses = Responses.select(lambda r: r.processed_text == processed_text and r.hero_id.id == hero_id)
+        else:
+            responses = Responses.select(lambda r: r.processed_text == processed_text)
 
         if len(responses):
-            if hero_id is not None:
-                for response in responses:
-                    if response.hero_id == hero_id:
-                        return response.response_link, response.hero_id.id
-            else:
-                response = random.choice(list(responses))
-                return response.response_link, response.hero_id.id
+            response = random.choice(list(responses))
+            return response.response_link, response.hero_id.id
         else:
             return None, None
 
@@ -96,7 +93,7 @@ class DatabaseAPI:
         Heroes(hero_name=hero_name, img_path=img_path, flair_css=flair_css)
 
     @db_session
-    def get_hero_id_from_table(self, hero_name):
+    def get_hero_id_by_name(self, hero_name):
         """Method to get hero's id from table.
 
         :param hero_name: Hero's name

--- a/util/database/database.py
+++ b/util/database/database.py
@@ -99,7 +99,7 @@ class DatabaseAPI:
         :param hero_name: Hero's name
         :return: Hero's id
         """
-        h = Heroes.get(hero_name=hero_name)
+        h = Heroes.get(lambda hero: hero.hero_name.lower() == hero_name)
         return h.id if h is not None else None
 
     @db_session

--- a/util/database/database.py
+++ b/util/database/database.py
@@ -172,7 +172,7 @@ class DatabaseAPI:
         """Method to add hero and it's responses to the db.
 
         :param hero_name: Hero name who's responses will be inserted
-        :param response_link_list: List with tuples in the form of (original_text, processed_text, link)
+        :param response_link_list: List with tuples in the form of (original_text, text, link)
         """
         h = Heroes(hero_name=hero_name, img_path=None, flair_css=None)
         commit()

--- a/util/logger.py
+++ b/util/logger.py
@@ -45,7 +45,7 @@ def setup_logger():
 
     # PRAW logging
     praw_logger = logging.getLogger(PRAW_LOGGER)
-    praw_logger.setLevel(logging.WARNING)
+    praw_logger.setLevel(log_level)
     praw_logger.addHandler(stream_handler)
     praw_logger.addHandler(praw_handler)
 

--- a/util/response_info.py
+++ b/util/response_info.py
@@ -1,0 +1,6 @@
+class ResponseInfo:
+    """Custom Class to store response info for passing in between functions
+    """
+    def __init__(self, hero_id, link):
+        self.hero_id = hero_id
+        self.link = link


### PR DESCRIPTION
One of the most common complaints are they didn't get the response for the hero that they expected. To provide a way to solve this, I came up with two new ways.

1. User(OP) can now request to update the response using another comment under bot's comment.
    The comment should be in format ```Try <hero_name>``` 

2. Users can now request for a hero specific response by adding ```<hero_name> ::``` prefix to the response.
    Has more priority than user's flair.

I prefer 1. over 2. personally, but I would like to know your input.

This PR also includes misc fixes.
