### PR TITLE
Get response set from dota2 wiki

### DIFF
--- a/config.py
+++ b/config.py
@@ -3,7 +3,6 @@ import os
 import json
 import urllib.request
 
-
 __author__ = 'Jonarzz'
 __maintainer__ = 'MePsyDuck'
 
@@ -83,21 +82,25 @@ FREQUENT_RESPONSES = {'denied', 'yes', 'not yet', 'no mana', 'not enough mana', 
                       'it s not time yet', 'ah', 'no', 'uh', 'ha ha', 'attack', 'haste', 'double damage', 'immortality',
                       'invisibility', 'illusion', 'regeneration', 'uh uh', 'ha', }
 
+#Hero and item responses not hardcoded here
+# Drawbacks: Can't be tweaked
+#TODO incorperate an exclusion set
 with urllib.request.urlopen('https://dota2.gamepedia.com/api.php?' +
                             'action=cargoquery&tables=heroes&fields=title&where=game'+
                             '+IS+NULL&limit=500&format=json') as url:
     HERO_NAME_RESPONSES = set()
-    for i in json.loads(url.read().decode())['cargoquery'] : HERO_NAME_RESPONSES.add(i['title']['title'].lower())
+    for i in json.loads(url.read().decode())['cargoquery']:
+        i = i['title']['title']
+        for c in ["'", "(", ")", ":", ",", "-"]: i = i.replace(c, " ")
+        HERO_NAME_RESPONSES.add(i.lower())
 
 with urllib.request.urlopen('https://dota2.gamepedia.com/api.php?'+
                             'action=cargoquery&tables=items&fields='+
                             'title&where=game+IS+NULL&limit=500&format=json') as url:
     ITEM_RESPONSES = set()
-    special_characters = ["'", "(", ")", ":", ","]
-    for i in json.loads(url.read().decode())['cargoquery'] :
+    for i in json.loads(url.read().decode())['cargoquery']:
         i = i['title']['title']
-        for c in special_characters:
-            i = i.replace(c, " ")
+        for c in ["'", "(", ")", ":", ",", "-"]: i = i.replace(c, " ")
         ITEM_RESPONSES.add(i.lower())
 
 # Add responses here as people report them. Taken from the old excluded responses list.

--- a/config.py
+++ b/config.py
@@ -1,6 +1,6 @@
 """Module in which the constants that are used by Dota Responses Bot are declared."""
 import os
-from util.response_request import request_hero_name_set, request_item_name_set
+from util.response_request import request_cargo_set
 
 __author__ = 'Jonarzz'
 __maintainer__ = 'MePsyDuck'
@@ -82,9 +82,13 @@ FREQUENT_RESPONSES = {'denied', 'yes', 'not yet', 'no mana', 'not enough mana', 
                       'invisibility', 'illusion', 'regeneration', 'uh uh', 'ha', }
 
 # Hero and item responses not hardcoded here
-# Drawbacks: Can't be tweaked
-HERO_NAME_RESPONSES = request_hero_name_set()
-ITEM_RESPONSES = request_item_name_set()
+HERO_NAME_RESPONSES = request_cargo_set('https://dota2.gamepedia.com/api.php?'+
+                                        'action=cargoquery&tables=heroes&fields=title&where=game'+
+                                        '+IS+NULL&limit=500&format=json')
+
+ITEM_RESPONSES = request_cargo_set('https://dota2.gamepedia.com/api.php?'+
+                                   'action=cargoquery&tables=items&fields='+
+                                   'title&where=game+IS+NULL&limit=500&format=json')
 
 # Add responses here as people report them. Taken from the old excluded responses list.
 COMMON_PHRASE_RESPONSES = {'earth shaker', 'shut up', 'skeleton king', 'it begins', 'i am', 'exactly so', 'very nice',

--- a/config.py
+++ b/config.py
@@ -1,5 +1,8 @@
 """Module in which the constants that are used by Dota Responses Bot are declared."""
 import os
+import json
+import urllib.request
+
 
 __author__ = 'Jonarzz'
 __maintainer__ = 'MePsyDuck'
@@ -80,56 +83,17 @@ FREQUENT_RESPONSES = {'denied', 'yes', 'not yet', 'no mana', 'not enough mana', 
                       'it s not time yet', 'ah', 'no', 'uh', 'ha ha', 'attack', 'haste', 'double damage', 'immortality',
                       'invisibility', 'illusion', 'regeneration', 'uh uh', 'ha', }
 
-# Note: Get them from here.
-# https://dota2.gamepedia.com/api.php?action=cargoquery&tables=items&fields=title&where=game+IS+NULL&limit=500&format=json
-ITEM_RESPONSES = {'crimson guard', 'vanguard', 'blades of attack', 'glimmer cape', 'aghanim s scepter', 'manta style',
-                  'battle fury', 'yasha and kaya', 'talisman of evasion', 'sentry ward', 'yasha',
-                  'mantle of intelligence', 'bracer', 'iron branch', 'guardian greaves', 'wraith band', 'phase boots',
-                  'blade mail', 'power treads', 'eaglesong', 'soul ring', 'point booster', 'satanic', 'arcane boots',
-                  'observer ward', 'aegis of the immortal', 'sacred relic', 'void stone', 'aeon disk', 'ogre axe',
-                  'echo sabre', 'demon edge', 'rod of atos', 'ring of tarrasque', 'healing salve',
-                  'armlet of mordiggian', 'headdress', 'wind lace', 'slippers of agility', 'kaya', 'perseverance',
-                  'octarine core', 'ring of regen', 'shiva s guard', 'linken s sphere', 'veil of discord',
-                  'helm of the dominator', 'gem of true sight', 'sange and yasha', 'quarterstaff', 'crown', 'lotus orb',
-                  'daedalus', 'sange', 'mekansm', 'bloodthorn', 'energy booster', 'mithril hammer', 'faerie fire',
-                  'necronomicon', 'platemail', 'stout shield', 'crystalys', 'robe of the magi', 'monkey king bar',
-                  'tome of knowledge', 'sage s mask', 'orb of venom', 'dragon lance', 'drum of endurance', 'nullifier',
-                  'kaya and sange', 'hood of defiance', 'smoke of deceit', 'urn of shadows', 'heart of tarrasque',
-                  'reaver', 'cheese', 'solar crest', 'aether lens', 'blink dagger', 'magic stick', 'hand of midas',
-                  'morbid mask', 'force staff', 'blight stone', 'mystic staff', 'quelling blade', 'refresher shard',
-                  'holy locket', 'maelstrom', 'hyperstone', 'animal courier', 'mjollnir', 'soul booster', 'buckler',
-                  'scythe of vyse', 'bottle', 'gloves of haste', 'pipe of insight', 'null talisman', 'ring of basilius',
-                  'band of elvenskin', 'spirit vessel', 'staff of wizardry', 'town portal scroll', 'orchid malevolence',
-                  'claymore', 'heaven s halberd', 'enchanted mango', 'aghanim s blessing', 'radiance', 'silver edge',
-                  'oblivion staff', 'ethereal blade', 'eye of skadi', 'eul s scepter of divinity', 'assault cuirass',
-                  'mask of madness', 'refresher orb', 'circlet', 'chainmail', 'infused raindrop', 'desolator',
-                  'magic wand', 'black king bar', 'observer and sentry wards', 'butterfly', 'clarity', 'shadow amulet',
-                  'skull basher', 'boots of speed', 'helm of iron will', 'medallion of courage', 'bloodstone',
-                  'divine rapier', 'gauntlets of strength', 'dagon', 'ghost scepter', 'boots of travel', 'moon shard',
-                  'abyssal blade', 'vitality booster', 'ring of protection', 'blade of alacrity', 'ring of health',
-                  'cloak', 'shadow blade', 'diffusal blade', 'tango', 'dust of appearance', 'belt of strength',
-                  'hurricane pike', 'vladmir s offering', 'tranquil boots', 'javelin', 'meteor hammer', 'broadsword',
-                  'ultimate orb'}
+with urllib.request.urlopen('https://dota2.gamepedia.com/api.php?' +
+                            'action=cargoquery&tables=heroes&fields=title&where=game'+
+                            '+IS+NULL&limit=500&format=json') as url:
+    HERO_NAME_RESPONSES = set()
+    for i in json.loads(url.read().decode())['cargoquery'] : HERO_NAME_RESPONSES.add(i['title']['title'])
 
-# Note: Get them from here
-# https://dota2.gamepedia.com/api.php?action=cargoquery&tables=heroes&fields=title&where=game+IS+NULL&limit=500&format=json
-HERO_NAME_RESPONSES = {'silencer', 'phantom assassin', 'clinkz', 'huskar', 'juggernaut', 'crystal maiden', 'pudge',
-                       'disruptor', 'queen of pain', 'wraith king', 'spectre', 'templar assassin', 'warlock',
-                       'earth spirit', 'viper', 'slark', 'weaver', 'alchemist', 'treant protector', 'axe', 'tidehunter',
-                       'invoker', 'kunkka', 'keeper of the light', 'undying', 'phoenix', 'terrorblade', 'doom',
-                       'broodmother', 'death prophet', 'earthshaker', 'mirana', 'storm spirit', 'bounty hunter',
-                       'clockwerk', 'lina', 'magnus', 'lifestealer', 'enigma', 'windranger', 'dark seer', 'drow ranger',
-                       'tiny', 'chaos knight', 'vengeful spirit', 'nyx assassin', 'ancient apparition', 'tusk',
-                       'ember spirit', 'io', 'outworld devourer', 'lion', 'underlord', 'lone druid', 'ursa', 'batrider',
-                       'riki', 'sven', 'ogre magi', 'beastmaster', 'anti mage', 'morphling', 'medusa', 'arc warden',
-                       'shadow demon', 'naga siren', 'slardar', 'bloodseeker', 'winter wyvern', 'leshrac', 'lycan',
-                       'omniknight', 'witch doctor', 'shadow shaman', 'sand king', 'necrophos', 'faceless void',
-                       'pangolier', 'grimstroke', 'dazzle', 'visage', 'spirit breaker', 'centaur warrunner',
-                       'monkey king', 'jakiro', 'dragon knight', 'abaddon', 'pugna', 'dark willow', 'night stalker',
-                       'luna', "nature s prophet", 'lich', 'bane', 'mars', 'phantom lancer', 'troll warlord', 'chen',
-                       'techies', 'skywrath mage', 'enchantress', 'razor', 'gyrocopter', 'tinker', 'zeus', 'meepo',
-                       'rubick', 'elder titan', 'brewmaster', 'venomancer', 'shadow fiend', 'puck', 'legion commander',
-                       'sniper', 'oracle', 'timbersaw', 'bristleback', 'snapfire', 'void spirit'}
+with urllib.request.urlopen('https://dota2.gamepedia.com/api.php?'+
+                            'action=cargoquery&tables=items&fields='+
+                            'title&where=game+IS+NULL&limit=500&format=json') as url:
+    ITEM_RESPONSES = set()
+    for i in json.loads(url.read().decode())['cargoquery'] : ITEM_RESPONSES.add(i['title']['title'])
 
 # Add responses here as people report them. Taken from the old excluded responses list.
 COMMON_PHRASE_RESPONSES = {'earth shaker', 'shut up', 'skeleton king', 'it begins', 'i am', 'exactly so', 'very nice',

--- a/config.py
+++ b/config.py
@@ -93,7 +93,12 @@ with urllib.request.urlopen('https://dota2.gamepedia.com/api.php?'+
                             'action=cargoquery&tables=items&fields='+
                             'title&where=game+IS+NULL&limit=500&format=json') as url:
     ITEM_RESPONSES = set()
-    for i in json.loads(url.read().decode())['cargoquery'] : ITEM_RESPONSES.add(i['title']['title'].lower())
+    special_characters = ["'", "(", ")", ":", ","]
+    for i in json.loads(url.read().decode())['cargoquery'] :
+        i = i['title']['title']
+        for c in special_characters:
+            i = i.replace(c, " ")
+        ITEM_RESPONSES.add(i.lower())
 
 # Add responses here as people report them. Taken from the old excluded responses list.
 COMMON_PHRASE_RESPONSES = {'earth shaker', 'shut up', 'skeleton king', 'it begins', 'i am', 'exactly so', 'very nice',

--- a/config.py
+++ b/config.py
@@ -1,7 +1,6 @@
 """Module in which the constants that are used by Dota Responses Bot are declared."""
 import os
-import json
-import urllib.request
+from util.response_request import request_hero_name_set, request_item_name_set
 
 __author__ = 'Jonarzz'
 __maintainer__ = 'MePsyDuck'
@@ -82,32 +81,10 @@ FREQUENT_RESPONSES = {'denied', 'yes', 'not yet', 'no mana', 'not enough mana', 
                       'it s not time yet', 'ah', 'no', 'uh', 'ha ha', 'attack', 'haste', 'double damage', 'immortality',
                       'invisibility', 'illusion', 'regeneration', 'uh uh', 'ha', }
 
-#Hero and item responses not hardcoded here
+# Hero and item responses not hardcoded here
 # Drawbacks: Can't be tweaked
-#TODO incorperate an  better exclusion set and populate it with the difference of responses from main
-SPECIAL_CHARACTERS = ["'", "(", ")", ":", ",", "-", "."]
-
-with urllib.request.urlopen('https://dota2.gamepedia.com/api.php?' +
-                            'action=cargoquery&tables=heroes&fields=title&where=game'+
-                            '+IS+NULL&limit=500&format=json') as url:
-    SELECTED_HERO_RESPONSES = {}
-    HERO_NAME_RESPONSES = set()
-    for i in json.loads(url.read().decode())['cargoquery']:
-        i = i['title']['title'].lower()
-        for c in SPECIAL_CHARACTERS: i = i.replace(c, " ")
-        if i in SELECTED_HERO_RESPONSES: continue
-        HERO_NAME_RESPONSES.add(i)
-
-with urllib.request.urlopen('https://dota2.gamepedia.com/api.php?'+
-                            'action=cargoquery&tables=items&fields='+
-                            'title&where=game+IS+NULL&limit=500&format=json') as url:
-    SELECTED_ITEM_RESPONSES = {}
-    ITEM_RESPONSES = set()
-    for i in json.loads(url.read().decode())['cargoquery']:
-        i = i['title']['title'].lower()
-        for c in SPECIAL_CHARACTERS: i = i.replace(c, " ")
-        if i in SELECTED_ITEM_RESPONSES: continue
-        ITEM_RESPONSES.add(i)
+HERO_NAME_RESPONSES = request_hero_name_set()
+ITEM_RESPONSES = request_item_name_set()
 
 # Add responses here as people report them. Taken from the old excluded responses list.
 COMMON_PHRASE_RESPONSES = {'earth shaker', 'shut up', 'skeleton king', 'it begins', 'i am', 'exactly so', 'very nice',

--- a/config.py
+++ b/config.py
@@ -87,13 +87,13 @@ with urllib.request.urlopen('https://dota2.gamepedia.com/api.php?' +
                             'action=cargoquery&tables=heroes&fields=title&where=game'+
                             '+IS+NULL&limit=500&format=json') as url:
     HERO_NAME_RESPONSES = set()
-    for i in json.loads(url.read().decode())['cargoquery'] : HERO_NAME_RESPONSES.add(i['title']['title'])
+    for i in json.loads(url.read().decode())['cargoquery'] : HERO_NAME_RESPONSES.add(i['title']['title'].lower())
 
 with urllib.request.urlopen('https://dota2.gamepedia.com/api.php?'+
                             'action=cargoquery&tables=items&fields='+
                             'title&where=game+IS+NULL&limit=500&format=json') as url:
     ITEM_RESPONSES = set()
-    for i in json.loads(url.read().decode())['cargoquery'] : ITEM_RESPONSES.add(i['title']['title'])
+    for i in json.loads(url.read().decode())['cargoquery'] : ITEM_RESPONSES.add(i['title']['title'].lower())
 
 # Add responses here as people report them. Taken from the old excluded responses list.
 COMMON_PHRASE_RESPONSES = {'earth shaker', 'shut up', 'skeleton king', 'it begins', 'i am', 'exactly so', 'very nice',

--- a/config.py
+++ b/config.py
@@ -84,24 +84,30 @@ FREQUENT_RESPONSES = {'denied', 'yes', 'not yet', 'no mana', 'not enough mana', 
 
 #Hero and item responses not hardcoded here
 # Drawbacks: Can't be tweaked
-#TODO incorperate an exclusion set
+#TODO incorperate an  better exclusion set and populate it with the difference of responses from main
+SPECIAL_CHARACTERS = ["'", "(", ")", ":", ",", "-", "."]
+
 with urllib.request.urlopen('https://dota2.gamepedia.com/api.php?' +
                             'action=cargoquery&tables=heroes&fields=title&where=game'+
                             '+IS+NULL&limit=500&format=json') as url:
+    SELECTED_HERO_RESPONSES = {}
     HERO_NAME_RESPONSES = set()
     for i in json.loads(url.read().decode())['cargoquery']:
-        i = i['title']['title']
-        for c in ["'", "(", ")", ":", ",", "-"]: i = i.replace(c, " ")
-        HERO_NAME_RESPONSES.add(i.lower())
+        i = i['title']['title'].lower()
+        for c in SPECIAL_CHARACTERS: i = i.replace(c, " ")
+        if i in SELECTED_HERO_RESPONSES: continue
+        HERO_NAME_RESPONSES.add(i)
 
 with urllib.request.urlopen('https://dota2.gamepedia.com/api.php?'+
                             'action=cargoquery&tables=items&fields='+
                             'title&where=game+IS+NULL&limit=500&format=json') as url:
+    SELECTED_ITEM_RESPONSES = {}
     ITEM_RESPONSES = set()
     for i in json.loads(url.read().decode())['cargoquery']:
-        i = i['title']['title']
-        for c in ["'", "(", ")", ":", ",", "-"]: i = i.replace(c, " ")
-        ITEM_RESPONSES.add(i.lower())
+        i = i['title']['title'].lower()
+        for c in SPECIAL_CHARACTERS: i = i.replace(c, " ")
+        if i in SELECTED_ITEM_RESPONSES: continue
+        ITEM_RESPONSES.add(i)
 
 # Add responses here as people report them. Taken from the old excluded responses list.
 COMMON_PHRASE_RESPONSES = {'earth shaker', 'shut up', 'skeleton king', 'it begins', 'i am', 'exactly so', 'very nice',

--- a/util/response_request.py
+++ b/util/response_request.py
@@ -1,0 +1,30 @@
+from util.str_utils import preprocess_text
+import requests
+
+
+def request_hero_name_set():
+    WEB_REQUEST = requests.get('https://dota2.gamepedia.com/api.php?' +
+                                'action=cargoquery&tables=heroes&fields=title&where=game'+
+                                '+IS+NULL&limit=500&format=json')
+    WEB_JSON = WEB_REQUEST.json()
+    SELECTED_HERO_RESPONSES = {}
+    HERO_NAME_RESPONSES = set()
+    for WEB_OBJECT in WEB_JSON['cargoquery']:
+        HERO_ENTRIES = preprocess_text(WEB_OBJECT['title']['title'])
+        if HERO_ENTRIES not in SELECTED_HERO_RESPONSES: 
+            HERO_NAME_RESPONSES.add(HERO_ENTRIES)
+    return (HERO_NAME_RESPONSES)
+        
+            
+def request_item_name_set():
+    WEB_REQUEST = requests.get('https://dota2.gamepedia.com/api.php?'+
+                                'action=cargoquery&tables=items&fields='+
+                                'title&where=game+IS+NULL&limit=500&format=json')
+    WEB_JSON = WEB_REQUEST.json()
+    SELECTED_ITEM_RESPONSES = {}
+    ITEM_RESPONSES = set()
+    for WEB_OBJECT in WEB_JSON['cargoquery']:
+        ITEM_ENTRIES = preprocess_text(WEB_OBJECT['title']['title'])
+        if ITEM_ENTRIES not in SELECTED_ITEM_RESPONSES: 
+            ITEM_RESPONSES.add(ITEM_ENTRIES)
+    return(ITEM_RESPONSES)

--- a/util/response_request.py
+++ b/util/response_request.py
@@ -2,29 +2,13 @@ from util.str_utils import preprocess_text
 import requests
 
 
-def request_hero_name_set():
-    WEB_REQUEST = requests.get('https://dota2.gamepedia.com/api.php?' +
-                                'action=cargoquery&tables=heroes&fields=title&where=game'+
-                                '+IS+NULL&limit=500&format=json')
-    WEB_JSON = WEB_REQUEST.json()
-    SELECTED_HERO_RESPONSES = {}
-    HERO_NAME_RESPONSES = set()
-    for WEB_OBJECT in WEB_JSON['cargoquery']:
-        HERO_ENTRIES = preprocess_text(WEB_OBJECT['title']['title'])
-        if HERO_ENTRIES not in SELECTED_HERO_RESPONSES: 
-            HERO_NAME_RESPONSES.add(HERO_ENTRIES)
-    return (HERO_NAME_RESPONSES)
-        
-            
-def request_item_name_set():
-    WEB_REQUEST = requests.get('https://dota2.gamepedia.com/api.php?'+
-                                'action=cargoquery&tables=items&fields='+
-                                'title&where=game+IS+NULL&limit=500&format=json')
-    WEB_JSON = WEB_REQUEST.json()
-    SELECTED_ITEM_RESPONSES = {}
-    ITEM_RESPONSES = set()
-    for WEB_OBJECT in WEB_JSON['cargoquery']:
-        ITEM_ENTRIES = preprocess_text(WEB_OBJECT['title']['title'])
-        if ITEM_ENTRIES not in SELECTED_ITEM_RESPONSES: 
-            ITEM_RESPONSES.add(ITEM_ENTRIES)
-    return(ITEM_RESPONSES)
+def request_cargo_set(url):
+    web_request = requests.get(url)
+    web_json = web_request.json()
+    SELECTED_EXCLUDED_RESPONSES = {}
+    cargo_set = set()
+    for objects in web_json['cargoquery']:
+        cargo = preprocess_text(objects['title']['title'])
+        if cargo not in  SELECTED_EXCLUDED_RESPONSES: 
+            cargo_set.add(cargo)
+    return cargo_set

--- a/util/response_request.py
+++ b/util/response_request.py
@@ -5,10 +5,7 @@ import requests
 def request_cargo_set(url):
     web_request = requests.get(url)
     web_json = web_request.json()
-    SELECTED_EXCLUDED_RESPONSES = {}
     cargo_set = set()
     for objects in web_json['cargoquery']:
-        cargo = preprocess_text(objects['title']['title'])
-        if cargo not in  SELECTED_EXCLUDED_RESPONSES: 
-            cargo_set.add(cargo)
+        cargo_set.add(preprocess_text(objects['title']['title']))
     return cargo_set


### PR DESCRIPTION
Noticed on config.py there was a todo getting the hero and item response set from the wiki, quickly created a solution that can keep the bot more up-to-date.

First pull request so apologies if formatting is not standard.